### PR TITLE
eos-factory-test: Record boot as successful on start

### DIFF
--- a/factory-test/eos-factory-test.service
+++ b/factory-test/eos-factory-test.service
@@ -5,6 +5,7 @@ After=systemd-user-sessions.service getty@tty1.service plymouth-quit.service gdm
 
 [Service]
 ExecStart=/usr/bin/xinit /usr/bin/xterm -bw 0 -e /var/eos-factory-test/start.sh
+ExecStartPost=-/usr/lib/grub/record-boot-status
 StandardOutput=syslog
 StandardError=inherit
 


### PR DESCRIPTION
GRUB marks the boot as failed when it loads the kernel, and it is up to
GDM to mark it as successful on regular boots -- so if the boot process
does not reach GDM we assume it was a failed boot and can act
accordingly.

This commit changes the factory test suite loader to mark the boot as
successful once the factory test suite is loaded. This does not look at
whether the factory test suite has completed successfully, since that
piece of software is normally out of our control.

https://phabricator.endlessm.com/T21108