### PR TITLE
factory-test: Drop StandardOutput= from unit file

### DIFF
--- a/factory-test/eos-factory-test.service
+++ b/factory-test/eos-factory-test.service
@@ -6,7 +6,6 @@ After=systemd-user-sessions.service getty@tty1.service plymouth-quit.service gdm
 [Service]
 ExecStart=/usr/bin/xinit /usr/bin/xterm -bw 0 -e /var/eos-factory-test/start.sh
 ExecStartPost=-/usr/lib/grub/record-boot-status
-StandardOutput=syslog
 StandardError=inherit
 
 [Install]

--- a/factory-test/eos-factory-test.service
+++ b/factory-test/eos-factory-test.service
@@ -6,7 +6,6 @@ After=systemd-user-sessions.service getty@tty1.service plymouth-quit.service gdm
 [Service]
 ExecStart=/usr/bin/xinit /usr/bin/xterm -bw 0 -e /var/eos-factory-test/start.sh
 ExecStartPost=-/usr/lib/grub/record-boot-status
-StandardError=inherit
 
 [Install]
 WantedBy=eos-factory-test.target


### PR DESCRIPTION
The 'syslog' value for StandardOutput is obsolete, leading to the
following warning in the logs:

 systemd[1]: /lib/systemd/system/eos-factory-test.service:9: Standard
  output type syslog is obsolete, automatically updating to journal.
  Please update your unit file, and consider removing the setting
  altogether.

Since we keep the default value for DefaultStandardOutput=journal in
system.conf, we can drop this setting here.

https://phabricator.endlessm.com/T32955