### PR TITLE
factory-test: Replace xinit & xterm with mutter & terminal application

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -13,8 +13,23 @@ AC_ARG_ENABLE([systemd],
 	enable_systemd=$enableval, enable_systemd=no)
 AM_CONDITIONAL(ENABLE_SYSTEMD, [test "$enable_systemd" = yes])
 
+AC_ARG_WITH([terminal],
+            [AS_HELP_STRING([--with-terminal],
+                            [Terminal application going to be launched])],
+            [TERMINAL="$withval"],
+            [TERMINAL="kgx"])
+AC_SUBST(TERMINAL)
+
+AC_ARG_WITH([terminal-parameters],
+            [AS_HELP_STRING([--with-terminal-parameters],
+                            [Pass parameters to terminal application])],
+            [TERMINAL_PARAM="$withval"],
+            [TERMINAL_PARAM="--title \"Endless OS Factory Test\" --wait"])
+AC_SUBST(TERMINAL_PARAM)
+
 AC_CONFIG_FILES([
 	Makefile
 	factory-test/Makefile
+	factory-test/eos-factory-test.service
 	mfgdata/Makefile])
 AC_OUTPUT

--- a/debian/control
+++ b/debian/control
@@ -9,7 +9,7 @@ Homepage: https://endlessm.com
 Package: eos-factory-tools
 Architecture: any
 Description: Endless factory tools
-Depends: ${misc:Depends}, dracut, xinit, xterm
+Depends: ${misc:Depends}, dracut, gnome-terminal, mutter
 Provides: eos-factory-test
 Replaces: eos-factory-test
 Conflicts: eos-factory-test

--- a/debian/rules
+++ b/debian/rules
@@ -4,7 +4,10 @@
 	dh $@ --with systemd
 
 override_dh_auto_configure:
-	dh_auto_configure -- --enable-systemd
+	dh_auto_configure -- \
+		--enable-systemd \
+		--with-terminal=gnome-terminal \
+		--with-terminal-parameters="--hide-menubar --title \"Endless OS Factory Test\" --maximize --wait"
 
 override_dh_systemd_start:
 	dh_systemd_start --no-start

--- a/factory-test/Makefile.am
+++ b/factory-test/Makefile.am
@@ -4,7 +4,7 @@ eos_factory_test_helper_LDADD = $(GLIB_LIBS) $(UDISKS_LIBS)
 eos_factory_test_helper_CFLAGS = $(GLIB_CFLAGS) $(UDISKS_CFLAGS)
 
 if ENABLE_SYSTEMD
-systemdunitdir=/lib/systemd/system
+systemdunitdir=$${prefix}/usr/lib/systemd/system
 dist_systemdunit_DATA = eos-factory-test-helper.service \
 	eos-factory-test.service \
 	eos-factory-test.target

--- a/factory-test/eos-factory-test.service
+++ b/factory-test/eos-factory-test.service
@@ -4,8 +4,16 @@ Conflicts=getty@tty1.service gdm.service plymouth-start.service
 After=systemd-user-sessions.service getty@tty1.service plymouth-quit.service gdm.service
 
 [Service]
-ExecStart=/usr/bin/xinit /usr/bin/xterm -bw 0 -e /var/eos-factory-test/start.sh
+Type=simple
+# Forcing root login makes pam_systemd register user sessions with the systemd
+# login manager systemd-logind.service. It prepares env "XDG_RUNTIME_DIR" and
+# "XDG_SESSION_ID" for mutter in wayland mode.
+User=root
+PAMName=login
+ExecStart=/usr/bin/mutter --wayland --no-x11 --display-server -- gnome-terminal --hide-menubar --title "Endless OS Factory Test" --maximize --wait -- /var/eos-factory-test/start.sh
 ExecStartPost=-/usr/lib/grub/record-boot-status
+# Give a seat binding to tty1 to the user session, so mutter shows up to tty1.
+TTYPath=/dev/tty1
 
 [Install]
 WantedBy=eos-factory-test.target

--- a/factory-test/eos-factory-test.service.in
+++ b/factory-test/eos-factory-test.service.in
@@ -10,7 +10,7 @@ Type=simple
 # "XDG_SESSION_ID" for mutter in wayland mode.
 User=root
 PAMName=login
-ExecStart=/usr/bin/mutter --wayland --no-x11 --display-server -- gnome-terminal --hide-menubar --title "Endless OS Factory Test" --maximize --wait -- /var/eos-factory-test/start.sh
+ExecStart=/usr/bin/mutter --wayland --no-x11 --display-server -- @TERMINAL@ @TERMINAL_PARAM@ -- /var/eos-factory-test/start.sh
 ExecStartPost=-/usr/lib/grub/record-boot-status
 # Give a seat binding to tty1 to the user session, so mutter shows up to tty1.
 TTYPath=/dev/tty1


### PR DESCRIPTION
Current eos-factory-test.service executes the command with xinit & term. However, EOS 7 is going to base on GNOME OS, which does not include xinit & xterm. Then, factory-test should use mutter as the display server in wayland mode and gnome-terminal (or kgx) instead.

The eos-factory-test.service needs:
* Make root user login to get the login session and running directory
  for mutter in wayland mode with PAMName [1]. When an user logins, the   pam_systemd registers user sessions with the systemd login manager systemd-logind.service. It prepares environment "XDG_RUNTIME_DIR" and "XDG_SESSION_ID" for mutter in wayland mode.
* Give the user session a seat by setting TTYPath=/dev/tty1 [2]. Then, mutter can show up to front.

And, because the service will execute mutter and gnome-terminal, instead of xinit and xterm, change the deb package dependencies accrodingly.

Besides, EOS 7 based on GNOME OS uses kgx (Console) as the terminal application. So, we have make the terminal application configurable for autotools.

[1]: https://www.freedesktop.org/software/systemd/man/latest/systemd.exec.html#PAMName=
[2]: https://www.freedesktop.org/software/systemd/man/latest/systemd.exec.html#TTYPath=

Fixes: https://github.com/endlessm/eos-build-meta/issues/65